### PR TITLE
More links, dark theme

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-    "presets": ["es2015", "react"]
+    "presets": ["@babel/preset-env", "@babel/preset-react"],
+    "plugins": ["@babel/plugin-proposal-object-rest-spread"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tmp
 node_modules
 npm-debug.log
 *.swp
+*.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: node_js
+node_js:
+- '12.13'
+script:
+- npm run build
+deploy:
+  provider: s3
+  access_key_id: AKIAZA4K6RW77XSCAMI2
+  secret_access_key:
+    secure: b4XpktTe5PGzPMRmWtPCbnjTZqLWBV9+ERp3vZY31sm7PigPpL0TQVI7gTVkVzugsmzflVQFehs2QqbSoiTDD7k+uF7RCUZ9SwfdlPf6j1QWU9ljLPBZEWMzfOFufYP0Ybx3YHslL+2Sdo2EJmaJhNL8slbMADm9V5LZwwrC8h4XNI2ZUQNH9EZNrLGauf8B9kffKCahZjjRPOESH4DBL0eCT4Wsp6Qmp4wzVUkdzAjEEOa6/rYCaJuh31cn9rMCat1ZGF8pvhgcG2okjbEe9WRveqjHWfOhEYm4bI518Z/J40hSRsFLm5nXEs560NP8qlkFUkpx1Zhla4a69dIPwJ2HKK1qoHbnXLFWbJD7DfxhXQKi1DcXGC9wTEqNFvSgAf02UhhV9JTCN/+moqTyIWfYuf7HnnsxO0Y49YT2hv8dO8tT1yYWyski+i1dCa0+mccFBylJ0tzJgEMR5BvNEwCuA8OpjWBdq9iWmCTKHQK84IcCQzunvufAAmy7BbqRu+hOYAilHYQoowy2POTjAaUJainNH1EYJYqY4Dpw45CFiw5EF4gGRURtqtysSioLxcW2gF6wDV3XbdKjxOu6OUq0ks3mdvjJ5y7gb18JeH1dlNwo8abLlNofFSwqK85Z60BqXOXC5xk4V8BdrKI3Q+bFyp1mRthpj/mbjdITxtg=
+  bucket: status.ksp-ckan.space
+  local-dir: dist
+  acl: public_read
+  on:
+    repo: KSP-CKAN/NetKAN-status
+    branch: master

--- a/package.json
+++ b/package.json
@@ -9,16 +9,16 @@
   "description": "Simple static site to display NetKAN indexing status",
   "keywords": [],
   "dependencies": {
-    "ajv": "^5.2.2",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-react": "^6.24.1",
-    "bootstrap": "^3.3.5",
-    "css-loader": "^0.28.7",
-    "fixed-data-table": "^0.6.4",
-    "jquery": "^3.2.1",
+    "@babel/preset-react": "^7.6.3",
+    "ajv": "^5.5.2",
+    "bootstrap": "^3.4.1",
+    "css-loader": "^0.28.11",
+    "fixed-data-table": "^0.6.5",
+    "jquery": "^3.4.1",
     "moment": "~2.18.1",
-    "react": "^15.6.1",
-    "react-dom": "^15.6.1",
+    "rc-menu": "^7.5.3",
+    "react": "^15.6.2",
+    "react-dom": "^15.6.2",
     "require": "~2",
     "style-loader": "^0.18.2"
   },
@@ -29,9 +29,11 @@
   "author": "Leon Wright",
   "license": "MIT",
   "devDependencies": {
-    "babel-core": "^6.10.4",
-    "babel-loader": "^7.1.2",
+    "@babel/core": "^7.6.4",
+    "@babel/plugin-proposal-object-rest-spread": "^7.6.2",
+    "@babel/preset-env": "^7.6.3",
+    "babel-loader": "^8.0.6",
     "html-webpack-plugin": "^2.30.1",
-    "webpack": "^3.5.6"
+    "webpack": "^3.12.0"
   }
 }

--- a/src/javascript/app.css
+++ b/src/javascript/app.css
@@ -1,0 +1,66 @@
+html, body {
+    margin:  0;
+    padding: 0;
+}
+input::-webkit-input-placeholder {
+    font-style: italic;
+}
+.public_fixedDataTable_main,
+.public_fixedDataTableRow_main {
+    border-color: rgba(255, 255, 255, 0.1);
+}
+.public_fixedDataTableRow_fixedColumnsDivider,
+.public_fixedDataTableCell_main {
+    border-color: rgba(255, 255, 255, 0.06);
+}
+.public_fixedDataTable_header,
+.public_fixedDataTable_header .public_fixedDataTableCell_main {
+    color:            rgba(255, 255, 255, 0.88);
+    background-color: rgba(40, 40, 40, 0.98);
+    background-image: linear-gradient(rgba(40, 40, 40, 0.98), rgba(32, 32, 32, 0.98));
+}
+.public_fixedDataTableRow_highlighted .public_fixedDataTableCell_main,
+.public_fixedDataTableCell_main {
+    background: inherit;
+}
+.public_fixedDataTableRow_even {
+    background-color: rgb(19, 19, 19);
+}
+.public_fixedDataTableRow_odd.public_fixedDataTableRow_highlighted {
+    background-color: rgb(27, 27, 27);
+}
+.public_fixedDataTableCell_cellContent {
+    padding: 2px 8px;
+}
+.error {
+    color: rgb(255, 100, 100);
+}
+a:link,
+a:visited {
+    color: rgb(62, 166, 255);
+    text-decoration: none;
+}
+a:hover,
+a:active {
+    text-decoration: underline;
+}
+.moduleMenu {
+    visibility: hidden;
+    opacity:    0;
+    margin-top: -1em;
+    transition: visibility 0s linear 300ms, opacity 300ms, margin-top 300ms ease-in;
+}
+.public_fixedDataTableRow_main:hover .moduleMenu {
+    visibility: visible;
+    opacity:    1;
+    margin-top: 0;
+    transition: visibility 0s linear 0s, opacity 300ms, margin-top 300ms ease-out;
+}
+.moduleMenu {
+    font-size: 8pt;
+    color: rgba(144, 144, 144, 0.7);
+}
+.moduleMenu a:link,
+.moduleMenu a:visited {
+    color: rgba(144, 144, 144, 0.9);
+}

--- a/src/javascript/app.css
+++ b/src/javascript/app.css
@@ -1,3 +1,5 @@
+/* Common layout */
+
 html, body {
     margin:  0;
     padding: 0;
@@ -5,39 +7,15 @@ html, body {
 input::-webkit-input-placeholder {
     font-style: italic;
 }
-.public_fixedDataTable_main,
-.public_fixedDataTableRow_main {
-    border-color: rgba(255, 255, 255, 0.1);
-}
-.public_fixedDataTableRow_fixedColumnsDivider,
-.public_fixedDataTableCell_main {
-    border-color: rgba(255, 255, 255, 0.06);
-}
-.public_fixedDataTable_header,
-.public_fixedDataTable_header .public_fixedDataTableCell_main {
-    color:            rgba(255, 255, 255, 0.88);
-    background-color: rgba(40, 40, 40, 0.98);
-    background-image: linear-gradient(rgba(40, 40, 40, 0.98), rgba(32, 32, 32, 0.98));
-}
 .public_fixedDataTableRow_highlighted .public_fixedDataTableCell_main,
 .public_fixedDataTableCell_main {
     background: inherit;
 }
-.public_fixedDataTableRow_even {
-    background-color: rgb(19, 19, 19);
-}
-.public_fixedDataTableRow_odd.public_fixedDataTableRow_highlighted {
-    background-color: rgb(27, 27, 27);
-}
 .public_fixedDataTableCell_cellContent {
     padding: 2px 8px;
 }
-.error {
-    color: rgb(255, 100, 100);
-}
 a:link,
 a:visited {
-    color: rgb(62, 166, 255);
     text-decoration: none;
 }
 a:hover,
@@ -58,9 +36,85 @@ a:active {
 }
 .moduleMenu {
     font-size: 8pt;
+}
+button {
+    border: 0;
+    border-radius: 2px;
+    padding: 5px 8px;
+    font-size: 14px;
+    font-weight: 500;
+    cursor: pointer;
+}
+
+
+/* Original light theme */
+
+.lightTheme .darkOnly {
+    display: none;
+}
+.lightTheme .outer {
+    background-color: #f0f0f0;
+}
+.lightTheme a:link,
+.lightTheme a:visited {
+    color: #009;
+}
+
+
+/* Dark theme */
+
+.darkTheme .lightOnly {
+    display: none;
+}
+.darkTheme .outer {
+    background-color: rgb(19, 19, 19);
+    color:            rgb(255, 255, 255);
+}
+.darkTheme h1 {
+    color: rgb(240, 240, 240);
+}
+.darkTheme button {
+    background-color: rgba(255, 255, 255, 0.1);
+    color: rgb(170, 170, 170);
+}
+.darkTheme .public_fixedDataTable_main,
+.darkTheme .public_fixedDataTableRow_main {
+    border-color: rgba(255, 255, 255, 0.1);
+}
+.darkTheme .public_fixedDataTableRow_fixedColumnsDivider,
+.darkTheme .public_fixedDataTableCell_main {
+    border-color: rgba(255, 255, 255, 0.06);
+}
+.darkTheme .public_fixedDataTable_header,
+.darkTheme .public_fixedDataTable_header .public_fixedDataTableCell_main {
+    color:            rgba(255, 255, 255, 0.88);
+    background-color: rgba(40, 40, 40, 0.98);
+    background-image: linear-gradient(rgba(40, 40, 40, 0.98), rgba(32, 32, 32, 0.98));
+}
+.darkTheme .public_fixedDataTableRow_even {
+    background-color: rgb(19, 19, 19);
+}
+.darkTheme .public_fixedDataTableRow_odd.public_fixedDataTableRow_highlighted {
+    background-color: rgb(27, 27, 27);
+}
+/* Possibly bad for color blindness
+.darkTheme .error {
+    color: rgb(255, 100, 100);
+}
+*/
+.darkTheme a:link,
+.darkTheme a:visited {
+    color: rgb(62, 166, 255);
+}
+.darkTheme .moduleMenu {
     color: rgba(144, 144, 144, 0.7);
 }
-.moduleMenu a:link,
-.moduleMenu a:visited {
+.darkTheme .moduleMenu a:link,
+.darkTheme .moduleMenu a:visited {
     color: rgba(144, 144, 144, 0.9);
+}
+.darkTheme input {
+    background-color: rgb(0, 0, 0);
+    color:            rgba(255, 255, 255, 0.88);
+    border-color:     rgba(255, 255, 255, 0.2);
 }

--- a/src/javascript/app.jsx
+++ b/src/javascript/app.jsx
@@ -3,66 +3,11 @@ import ReactDom from 'react-dom';
 import NetKANs from './components/NetKANs.jsx';
 import datatableStyles from
   '../../node_modules/fixed-data-table/dist/fixed-data-table.min.css';
-
-var sheet = document.createElement('style');
-sheet.type = 'text/css';
-sheet.innerHTML = `
-html, body {
-    color: rgb(255, 255, 255);
-    background-color: rgb(19, 19, 19);
-    font-family: sans-serif;
-}
-#content .public_fixedDataTable_main,
-#content .public_fixedDataTableRow_main,
-#content .public_fixedDataTableRow_fixedColumnsDivider,
-#content .public_fixedDataTableRow_even {
-    color: rgb(255, 255, 255);
-    background-color: rgb(19, 19, 19);
-    font-family: sans-serif;
-    border-color: rgba(255, 255, 255, 0.1);
-}
-#content .public_fixedDataTable_header, #content .public_fixedDataTable_header .public_fixedDataTableCell_main {
-    background-color: rgba(40, 40, 40, 0.98);
-    background-image: linear-gradient(rgba(40, 40, 40, 0.98), rgba(32, 32, 32, 0.98));
-}
-#content .public_fixedDataTableCell_main {
-    background-color: inherit;
-    background-image: inherit;
-    border-color: rgba(255, 255, 255, 0.1);
-}
-#content .public_fixedDataTableRow_odd {
-    color: rgb(255, 255, 255);
-    background-color: rgb(27, 27, 27);
-    font-family: sans-serif;
-    border-color: rgba(255, 255, 255, 0.1);
-}
-input::-webkit-input-placeholder {
-    font-style: italic;
-}
-a:link, a:visited {
-    text-decoration: none;
-    color: rgb(62, 166, 255);
-}
-a:hover, a:active {
-    text-decoration: underline;
-}
-.moduleMenu {
-    visibility: hidden;
-}
-.moduleCell:hover .moduleMenu {
-    visibility: visible;
-}
-.moduleMenu, .moduleMenu a:link, .moduleMenu a:visited {
-    color: rgb(144, 144, 144);
-}
-`;
-document.body.appendChild(sheet);
-
-document.body.innerHTML += '<div id="content"></div>';
+import customStyles from './app.css';
 
 ReactDom.render(
   <NetKANs
     url="http://status.ksp-ckan.space/status/netkan.json"
     pollInterval={300000} />,
-  document.getElementById('content')
+  document.body
 );

--- a/src/javascript/app.jsx
+++ b/src/javascript/app.jsx
@@ -6,7 +6,56 @@ import datatableStyles from
 
 var sheet = document.createElement('style');
 sheet.type = 'text/css';
-sheet.innerHTML = 'html,body{background-color:#f0f0f0;} input::-webkit-input-placeholder{font-style:italic;} a:link,a:visited{text-decoration:none;color:#009;} a:hover,a:active{text-decoration:underline;}';
+sheet.innerHTML = `
+html, body {
+    color: rgb(255, 255, 255);
+    background-color: rgb(19, 19, 19);
+    font-family: sans-serif;
+}
+#content .public_fixedDataTable_main,
+#content .public_fixedDataTableRow_main,
+#content .public_fixedDataTableRow_fixedColumnsDivider,
+#content .public_fixedDataTableRow_even {
+    color: rgb(255, 255, 255);
+    background-color: rgb(19, 19, 19);
+    font-family: sans-serif;
+    border-color: rgba(255, 255, 255, 0.1);
+}
+#content .public_fixedDataTable_header, #content .public_fixedDataTable_header .public_fixedDataTableCell_main {
+    background-color: rgba(40, 40, 40, 0.98);
+    background-image: linear-gradient(rgba(40, 40, 40, 0.98), rgba(32, 32, 32, 0.98));
+}
+#content .public_fixedDataTableCell_main {
+    background-color: inherit;
+    background-image: inherit;
+    border-color: rgba(255, 255, 255, 0.1);
+}
+#content .public_fixedDataTableRow_odd {
+    color: rgb(255, 255, 255);
+    background-color: rgb(27, 27, 27);
+    font-family: sans-serif;
+    border-color: rgba(255, 255, 255, 0.1);
+}
+input::-webkit-input-placeholder {
+    font-style: italic;
+}
+a:link, a:visited {
+    text-decoration: none;
+    color: rgb(62, 166, 255);
+}
+a:hover, a:active {
+    text-decoration: underline;
+}
+.moduleMenu {
+    visibility: hidden;
+}
+.moduleCell:hover .moduleMenu {
+    visibility: visible;
+}
+.moduleMenu, .moduleMenu a:link, .moduleMenu a:visited {
+    color: rgb(144, 144, 144);
+}
+`;
 document.body.appendChild(sheet);
 
 document.body.innerHTML += '<div id="content"></div>';

--- a/src/javascript/app.jsx
+++ b/src/javascript/app.jsx
@@ -5,6 +5,9 @@ import datatableStyles from
   '../../node_modules/fixed-data-table/dist/fixed-data-table.min.css';
 import customStyles from './app.css';
 
+document.body.className = window.localStorage.getItem('darkTheme')
+    ? 'darkTheme' : 'lightTheme';
+
 ReactDom.render(
   <NetKANs
     url="http://status.ksp-ckan.space/status/netkan.json"

--- a/src/javascript/components/NetKANs.jsx
+++ b/src/javascript/components/NetKANs.jsx
@@ -100,6 +100,12 @@ export default class NetKANs extends React.Component {
     }
     return val;
   }
+  _toggleTheme() {
+      var classes = document.body.classList;
+      classes.toggle('lightTheme');
+      classes.toggle('darkTheme');
+      window.localStorage.setItem('darkTheme', classes.contains('darkTheme'));
+  }
   render() {
     const sortBy = this.state.sortBy;
     const sortDir = this.state.sortDir;
@@ -130,19 +136,16 @@ export default class NetKANs extends React.Component {
     const divstyle = {
       fontSize:        '9pt',
       fontFamily:      'sans-serif',
-      backgroundColor: 'rgb(19, 19, 19)',
-      color:           'rgb(255, 255, 255)',
-      padding:         '5px'
+      padding:         '5px',
     };
     const h1style = {
-      color:              'rgb(240, 240, 240)',
       fontSize:           '16pt',
       margin:             '0',
       padding:            '5px 0',
       paddingLeft:        '72px',
       backgroundImage:    'url(favicon.ico)',
       backgroundPosition: 'left center',
-      backgroundRepeat:   'no-repeat'
+      backgroundRepeat:   'no-repeat',
     };
     const inputstyle = {
       float:    'right',
@@ -150,14 +153,19 @@ export default class NetKANs extends React.Component {
       width:    '20em',
       fontSize: '11pt',
       padding:  '1px 3px',
-      backgroundColor: 'rgb(0, 0, 0)',
-      color:    'rgba(255, 255, 255, 0.88)',
-      borderColor: 'rgba(255, 255, 255, 0.2)',
+    };
+    const buttonstyle = {
+      float:    'right',
+      margin:   '1px 5px',
     };
 
     return (
-      <div style={divstyle}>
+      <div style={divstyle} className="outer">
         <input onChange={this._onFilterChange} placeholder='filter...' style={inputstyle} autoFocus='true' type='search' />
+        <button onClick={this._toggleTheme} style={buttonstyle} title="Toggle theme">
+          <span className="darkOnly">☀</span>
+          <span className="lightOnly">🌙</span>
+        </button>
         <h1 style={h1style}>NetKANs Indexed</h1>
         <Table
           rowHeight={40}

--- a/src/javascript/components/NetKANs.jsx
+++ b/src/javascript/components/NetKANs.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Table, Column} from 'fixed-data-table';
+import {Table, Column, Cell} from 'fixed-data-table';
 import $ from 'jquery';
 
 import renderDate from '../lib/renderDate.js';
@@ -77,10 +77,14 @@ export default class NetKANs extends React.Component {
       filterId: e.target.value
     });
   }
-  _renderHeader(label, cellDataKey) {
-    return (
-      <a onClick={this._updateSort.bind(null, cellDataKey)}>{label}</a>
-    );
+  _sortDirArrow(key) {
+    if (key !== this.state.sortBy) {
+        return '';
+    }
+    return this.state.sortDir === 'DESC' ? ' ▾' : ' ▴';
+  }
+  _header(key, name) {
+      return <Cell onClick={this._updateSort.bind(null, key)}>{name} {this._sortDirArrow(key)}</Cell>;
   }
   render() {
     const sortBy = this.state.sortBy;
@@ -110,19 +114,12 @@ export default class NetKANs extends React.Component {
         sortVal * -1 : sortVal;
     });
 
-    const sortDirArrow = (key) => {
-      if (key !== this.state.sortBy) {
-        return ''
-      }
-      return this.state.sortDir === 'DESC' ?
-        ' ▾' : ' ▴'
-    };
 
     const divstyle = {
       fontSize: '9pt'
     };
     const h1style = {
-      color:              '#333',
+      color:              'rgb(240, 240, 240)',
       fontSize:           '16pt',
       margin:             '5px 0',
       paddingLeft:        '72px',
@@ -135,7 +132,10 @@ export default class NetKANs extends React.Component {
       margin:   '1px 5px',
       width:    '20em',
       fontSize: '11pt',
-      padding:  '1px 3px'
+      padding:  '1px 3px',
+      backgroundColor: 'rgb(0, 0, 0)',
+      color:    'rgba(255, 255, 255, 0.88)',
+      borderColor: 'rgba(255, 255, 255, 0.2)',
     };
 
     return (
@@ -145,53 +145,61 @@ export default class NetKANs extends React.Component {
         <Table
           rowHeight={40}
           headerHeight={30}
-          rowGetter={index => rows[index]}
           rowsCount={rows.length}
           width={this.state.tableWidth}
           height={this.state.tableHeight}
           overflowX="auto"
           overflowY="auto">
           <Column
-            headerRenderer={this._renderHeader.bind(this)}
-            cellRenderer={id => <a href={"https://github.com/KSP-CKAN/NetKAN/tree/master/NetKAN/" + id + ".netkan"}>{id}</a>}
-            dataKey="id"
+            header={this._header('id', 'NetKAN')}
+            cell={({rowIndex, ...props}) => (
+                <Cell className="moduleCell" {...props}>
+                    <a href={"https://github.com/KSP-CKAN/NetKAN/tree/master/NetKAN/" + rows[rowIndex].id + ".netkan"}>{rows[rowIndex].id}</a>
+                    <div className="moduleMenu">
+                        <a href={"https://github.com/KSP-CKAN/NetKAN/commits/master/NetKAN/" + rows[rowIndex].id + ".netkan"}>History</a>
+                        { [" | ", <a href={"https://github.com/KSP-CKAN/CKAN-meta/tree/master/" + rows[rowIndex].id}>Metadata</a>] }
+                        { 'homepage' in rows[rowIndex]
+                            && [" | ", <a href={rows[rowIndex].homepage}>Homepage</a>] }
+                        { 'spacedock' in rows[rowIndex]
+                            && [" | ", <a href={rows[rowIndex].spacedock}>SpaceDock</a>] }
+                        { 'repository' in rows[rowIndex]
+                            && [" | ", <a href={rows[rowIndex].repository}>Repository</a>] }
+                        { 'curse' in rows[rowIndex]
+                            && [" | ", <a href={rows[rowIndex].curse}>Curse</a>] }
+                        { 'bugtracker' in rows[rowIndex]
+                            && [" | ", <a href={rows[rowIndex].bugtracker}>Bug Tracker</a>] }
+                    </div>
+                </Cell>
+            )}
             fixed={true}
-            label={'NetKAN' + sortDirArrow('id')}
             width={200}
             flexGrow={1}
           />
           <Column
-            headerRenderer={this._renderHeader.bind(this)}
-            cellRenderer={renderDate}
-            dataKey="last_checked"
+            header={this._header('last_checked', 'Last Checked')}
+            cell={({rowIndex, ...props}) => (<Cell {...props}>{renderDate(rows[rowIndex].last_checked)}</Cell>)}
             fixed={true}
-            label={'Last Checked' + sortDirArrow('last_checked')}
             width={120}
             flexGrow={0}
           />
           <Column
-            headerRenderer={this._renderHeader.bind(this)}
-            cellRenderer={renderDate}
-            dataKey="last_inflated"
+            header={this._header('last_inflated', 'Last Inflated')}
+            cell={({rowIndex, ...props}) => (<Cell {...props}>{renderDate(rows[rowIndex].last_inflated)}</Cell>)}
             fixed={true}
-            label={'Last Inflated' + sortDirArrow('last_inflated')}
             width={120}
             flexGrow={0}
           />
           <Column
-            headerRenderer={this._renderHeader.bind(this)}
-            cellRenderer={renderDate}
-            dataKey="last_indexed"
+            header={this._header('last_indexed', 'Last Indexed')}
+            cell={({rowIndex, ...props}) => (<Cell {...props}>{renderDate(rows[rowIndex].last_indexed)}</Cell>)}
             fixed={true}
-            label={'Last Indexed' + sortDirArrow('last_indexed')}
             width={120}
             flexGrow={0}
           />
           <Column
-            headerRenderer={this._renderHeader.bind(this)}
-            dataKey="last_error"
+            header={this._header('last_error', 'Error')}
+            cell={({rowIndex, ...props}) => (<Cell {...props}>{rows[rowIndex].last_error}</Cell>)}
             fixed={false}
-            label={'Last Error' + sortDirArrow('last_error')}
             width={200}
             flexGrow={4}
           />

--- a/src/javascript/components/NetKANs.jsx
+++ b/src/javascript/components/NetKANs.jsx
@@ -66,10 +66,10 @@ export default class NetKANs extends React.Component {
     this._updateTimer = setTimeout(this._updateTableSize, 16);
   }
   _updateTableSize() {
-    const widthOffset = window.innerWidth < 680 ? 0 : 20;
+    const widthOffset = window.innerWidth < 680 ? 0 : 10;
     this.setState({
       tableWidth: window.innerWidth - widthOffset,
-      tableHeight: window.innerHeight - 50,
+      tableHeight: window.innerHeight - 45,
     });
   }
   _onFilterChange(e) {
@@ -86,14 +86,16 @@ export default class NetKANs extends React.Component {
   _header(key, name) {
     return <Cell onClick={this._updateSort.bind(null, key)}>{name} {this._sortDirArrow(key)}</Cell>;
   }
-  _resourcesList({resources}) {
-    var val = [];
+  _resourcesList({id, resources}) {
+    var val = [
+        <a href={"https://github.com/KSP-CKAN/NetKAN/commits/master/NetKAN/" + id + ".netkan"}>history</a>,
+        " | ",
+        <a href={"https://github.com/KSP-CKAN/CKAN-meta/tree/master/" + id}>metadata</a>
+    ];
     if (resources) {
-      for (const key of Object.keys(resources)) {
-        if (!key.startsWith('x_')) {
-          val.push(' | ');
-          val.push(<a href={resources[key]}>{key}</a>);
-        }
+      for (const key of Object.keys(resources).filter(name => !name.startsWith('x_')).sort()) {
+        val.push(' | ');
+        val.push(<a href={resources[key]}>{key}</a>);
       }
     }
     return val;
@@ -111,29 +113,32 @@ export default class NetKANs extends React.Component {
 
     rows.sort((a, b) => {
       let sortVal = 0;
-      a = a[sortBy] ?
-        a[sortBy].toLowerCase() : '';
-      b = b[sortBy] ?
-        b[sortBy].toLowerCase() : '';
-
-      if (a > b) {
+      var aVal = a[sortBy] ? a[sortBy].toLowerCase() : '';
+      var bVal = b[sortBy] ? b[sortBy].toLowerCase() : '';
+      if (aVal > bVal) {
         sortVal = 1;
-      }
-      if (a < b) {
+      } else if (aVal < bVal) {
         sortVal = -1;
+      } else if (sortBy !== 'id') {
+        sortVal = a.id < b.id ?  1
+                : a.id > b.id ? -1
+                :                0;
       }
-      return sortDir === 'DESC' ?
-        sortVal * -1 : sortVal;
+      return sortDir === 'DESC' ? sortVal * -1 : sortVal;
     });
 
-
     const divstyle = {
-      fontSize: '9pt'
+      fontSize:        '9pt',
+      fontFamily:      'sans-serif',
+      backgroundColor: 'rgb(19, 19, 19)',
+      color:           'rgb(255, 255, 255)',
+      padding:         '5px'
     };
     const h1style = {
       color:              'rgb(240, 240, 240)',
       fontSize:           '16pt',
-      margin:             '5px 0',
+      margin:             '0',
+      padding:            '5px 0',
       paddingLeft:        '72px',
       backgroundImage:    'url(favicon.ico)',
       backgroundPosition: 'left center',
@@ -165,14 +170,10 @@ export default class NetKANs extends React.Component {
           <Column
             header={this._header('id', 'NetKAN')}
             cell={({rowIndex, ...props}) => (
-                <Cell className="moduleCell" {...props}>
-                    <a href={"https://github.com/KSP-CKAN/NetKAN/tree/master/NetKAN/" + rows[rowIndex].id + ".netkan"}>{rows[rowIndex].id}</a>
-                    <div className="moduleMenu">
-                        <a href={"https://github.com/KSP-CKAN/NetKAN/commits/master/NetKAN/" + rows[rowIndex].id + ".netkan"}>history</a>
-                        { [" | ", <a href={"https://github.com/KSP-CKAN/CKAN-meta/tree/master/" + rows[rowIndex].id}>metadata</a>] }
-                        { this._resourcesList(rows[rowIndex]) }
-                    </div>
-                </Cell>
+              <Cell {...props}>
+                <a href={"https://github.com/KSP-CKAN/NetKAN/tree/master/NetKAN/" + rows[rowIndex].id + ".netkan"}>{rows[rowIndex].id}</a>
+                <div className="moduleMenu">{this._resourcesList(rows[rowIndex])}</div>
+              </Cell>
             )}
             fixed={true}
             width={250}
@@ -201,7 +202,7 @@ export default class NetKANs extends React.Component {
           />
           <Column
             header={this._header('last_error', 'Error')}
-            cell={({rowIndex, ...props}) => (<Cell {...props}>{rows[rowIndex].last_error}</Cell>)}
+            cell={({rowIndex, ...props}) => (<Cell className="error" {...props}>{rows[rowIndex].last_error}</Cell>)}
             fixed={false}
             width={200}
             flexGrow={4}

--- a/src/javascript/components/NetKANs.jsx
+++ b/src/javascript/components/NetKANs.jsx
@@ -90,8 +90,10 @@ export default class NetKANs extends React.Component {
     var val = [];
     if (resources) {
       for (const key of Object.keys(resources)) {
-        val.push(' | ');
-        val.push(<a href={resources[key]}>{key}</a>);
+        if (!key.startsWith('x_')) {
+          val.push(' | ');
+          val.push(<a href={resources[key]}>{key}</a>);
+        }
       }
     }
     return val;
@@ -173,7 +175,7 @@ export default class NetKANs extends React.Component {
                 </Cell>
             )}
             fixed={true}
-            width={200}
+            width={250}
             flexGrow={1}
           />
           <Column

--- a/src/javascript/components/NetKANs.jsx
+++ b/src/javascript/components/NetKANs.jsx
@@ -84,7 +84,17 @@ export default class NetKANs extends React.Component {
     return this.state.sortDir === 'DESC' ? ' ▾' : ' ▴';
   }
   _header(key, name) {
-      return <Cell onClick={this._updateSort.bind(null, key)}>{name} {this._sortDirArrow(key)}</Cell>;
+    return <Cell onClick={this._updateSort.bind(null, key)}>{name} {this._sortDirArrow(key)}</Cell>;
+  }
+  _resourcesList({resources}) {
+    var val = [];
+    if (resources) {
+      for (const key of Object.keys(resources)) {
+        val.push(' | ');
+        val.push(<a href={resources[key]}>{key}</a>);
+      }
+    }
+    return val;
   }
   render() {
     const sortBy = this.state.sortBy;
@@ -156,18 +166,9 @@ export default class NetKANs extends React.Component {
                 <Cell className="moduleCell" {...props}>
                     <a href={"https://github.com/KSP-CKAN/NetKAN/tree/master/NetKAN/" + rows[rowIndex].id + ".netkan"}>{rows[rowIndex].id}</a>
                     <div className="moduleMenu">
-                        <a href={"https://github.com/KSP-CKAN/NetKAN/commits/master/NetKAN/" + rows[rowIndex].id + ".netkan"}>History</a>
-                        { [" | ", <a href={"https://github.com/KSP-CKAN/CKAN-meta/tree/master/" + rows[rowIndex].id}>Metadata</a>] }
-                        { 'homepage' in rows[rowIndex]
-                            && [" | ", <a href={rows[rowIndex].homepage}>Homepage</a>] }
-                        { 'spacedock' in rows[rowIndex]
-                            && [" | ", <a href={rows[rowIndex].spacedock}>SpaceDock</a>] }
-                        { 'repository' in rows[rowIndex]
-                            && [" | ", <a href={rows[rowIndex].repository}>Repository</a>] }
-                        { 'curse' in rows[rowIndex]
-                            && [" | ", <a href={rows[rowIndex].curse}>Curse</a>] }
-                        { 'bugtracker' in rows[rowIndex]
-                            && [" | ", <a href={rows[rowIndex].bugtracker}>Bug Tracker</a>] }
+                        <a href={"https://github.com/KSP-CKAN/NetKAN/commits/master/NetKAN/" + rows[rowIndex].id + ".netkan"}>history</a>
+                        { [" | ", <a href={"https://github.com/KSP-CKAN/CKAN-meta/tree/master/" + rows[rowIndex].id}>metadata</a>] }
+                        { this._resourcesList(rows[rowIndex]) }
                     </div>
                 </Cell>
             )}


### PR DESCRIPTION
My suggestion for a dark theme was very popular (3 upvotes just from @DasSkelett alone!), so here it is, borrowed from Youtube via developer tools.

Also when you hover a mod cell more hyperlinks appear to make it more convenient to get to the netkan's commit history and the .ckan files' folder. These will be accompanied by other links if/when we start setting them into the status objects (trivial to do in the Indexer if we decide to go that route): Homepage, SpaceDock, Repository, Curse, Bug Tracker.

![image](https://user-images.githubusercontent.com/1559108/67699871-e08a5800-f97a-11e9-88f2-52f7495f49ee.png)

Compilation and testing cheat sheet:

1. Temporarily edit `src/javascript/app.jsx` to change `http://status.ksp-ckan.space/status/netkan.json` to `netkan.json`
2. `npm install`
3. `npm run build && ( cd dist; rm netkan.json; wget http://status.ksp-ckan.space/status/netkan.json && python3 -m http.server 5000 )`
4. Open in browser: http://127.0.0.1:5000/