### PR TITLE
Checkboxes to show or hide active or frozen mods

### DIFF
--- a/src/javascript/app.css
+++ b/src/javascript/app.css
@@ -102,6 +102,9 @@ button {
     color: rgb(255, 100, 100);
 }
 */
+.darkTheme label {
+    color: rgba(160, 160, 160, 0.9);
+}
 .darkTheme a:link,
 .darkTheme a:visited {
     color: rgb(62, 166, 255);


### PR DESCRIPTION
## Motivation

The new Infra has allowed us to persist status data about frozen mods, rather than dumping only the statuses of mods crawled in the current pass. If you attempt to use the status page to monitor active problems, old frozen mods with errors will clutter the list even though we've already taken corrective action by freezing them.

## Changes

Now by default on page load, active mods are shown and frozen mods are hidden. There are checkboxes in the upper right to show or hide each group. These checkboxes' values are **not** saved/loaded across page refreshes, because while you might conceivably want to peek at frozen mods right now, it's highly unlikely that you'll be interested in them forever.

NOTE: The active/frozen statuses of mods in the below screenshots are faked because we do not have accurate values for this property due to errors in KSP-CKAN/NetKAN-Infra#96. This should be addressed once KSP-CKAN/NetKAN-Infra#100 is merged. To simulate having valid data for testing, temporarily add this before the `setState` call in `loadNetKANsFromServer`:

```javascript
        // XXX - DO NOT COMMIT, TESTING ONLY
        var aDayAgo = new Date();
        aDayAgo.setDate(aDayAgo.getDate() - 1);
        netkan.forEach((row, index) => {
          var dt = new Date(row.last_checked);
          if (dt < aDayAgo) {
            row.frozen = true;
          }
        });
```

![image](https://user-images.githubusercontent.com/1559108/69271296-33ca8180-0b9a-11ea-8dcd-4fb5446f2f60.png)

Frozen mods are shown in a ~~strikethrough~~ style:

![image](https://user-images.githubusercontent.com/1559108/69271882-51e4b180-0b9b-11ea-8e3f-44e2c59ca21e.png)

Fixes KSP-CKAN/NetKAN-Infra#60.