### PR TITLE
Sort warnings

### DIFF
--- a/src/javascript/components/NetKANs.jsx
+++ b/src/javascript/components/NetKANs.jsx
@@ -143,8 +143,38 @@ export default class NetKANs extends React.Component {
 
     rows.sort((a, b) => {
       let sortVal = 0;
-      var aVal = a[sortBy] ? a[sortBy].toLowerCase() : '';
-      var bVal = b[sortBy] ? b[sortBy].toLowerCase() : '';
+      var aVal = '';
+      var bVal = '';
+      if (sortBy === 'last_error') {
+        if (a.last_error) {
+          if (b.last_error) {
+            // Two errors, compare them
+            aVal = a.last_error;
+            bVal = b.last_error;
+          } else {
+            // Errors sort to top
+            return -1;
+          }
+        } else if (b.last_error) {
+          // Errors sort to top
+          return 1;
+        } else if (a.last_warnings) {
+          if (b.last_warnings) {
+            // Two warnings, compare them
+            aVal = a.last_warnings;
+            bVal = b.last_warnings;
+          } else {
+            // Warnings sort above nothing
+            return -1;
+          }
+        } else if (b.last_warnings) {
+          // Warnings sort above nothing
+          return 1;
+        }
+      } else {
+        aVal = a[sortBy] ? a[sortBy].toLowerCase() : '';
+        bVal = b[sortBy] ? b[sortBy].toLowerCase() : '';
+      }
       if (aVal > bVal) {
         sortVal = 1;
       } else if (aVal < bVal) {

--- a/src/javascript/components/NetKANs.jsx
+++ b/src/javascript/components/NetKANs.jsx
@@ -135,8 +135,9 @@ export default class NetKANs extends React.Component {
       this.state.filterId
         ? this.state.data.filter(row => {
             var filt = this.state.filterId.toLowerCase();
-            return (row['id'].toLowerCase().indexOf(filt) !== -1)
-              || (row['last_error'] && row['last_error'].toLowerCase().indexOf(filt) !== -1);
+            return (row.id.toLowerCase().indexOf(filt) !== -1)
+              || (row.last_error && row.last_error.toLowerCase().indexOf(filt) !== -1)
+              || (row.last_warnings && row.last_warnings.toLowerCase().indexOf(filt) !== -1);
           })
         : this.state.data
     ).filter(row => row.frozen ? this.state.showFrozen : this.state.showActive);


### PR DESCRIPTION
## Problem

Warnings are live (see #13)! But if you sort by the errors/warnings column, only the errors actually sort, and the warnings are strewn throughout the table as if they weren't there.

![image](https://user-images.githubusercontent.com/1559108/82163881-4be23b80-9873-11ea-82f6-0a278b571f89.png)

## Cause

The current sort logic assumes that a column will pull from only one property, but this column pulls from `last_error` and `last_warnings`. We need to consider both somehow.

## Changes

Now the errors sort to the top, followed by the warnings, followed by everything else.