### PR TITLE
Toggleable filters for (non-)metanetkans

### DIFF
--- a/src/javascript/components/NetKANs.jsx
+++ b/src/javascript/components/NetKANs.jsx
@@ -14,6 +14,8 @@ export default class NetKANs extends React.Component {
     this._onFilterChange = this._onFilterChange.bind(this);
     this._toggleActive = this._toggleActive.bind(this);
     this._toggleFrozen = this._toggleFrozen.bind(this);
+    this._toggleMeta = this._toggleMeta.bind(this);
+    this._toggleNonmeta = this._toggleNonmeta.bind(this);
     this.state = {
       data: [],
       filterText: '',
@@ -27,6 +29,8 @@ export default class NetKANs extends React.Component {
       frozenCount: 0,
       showActive: true,
       showFrozen: false,
+      showMeta: true,
+      showNonmeta: true,
     }
 
     if (window.addEventListener) {
@@ -54,6 +58,8 @@ export default class NetKANs extends React.Component {
           data: netkan,
           activeCount: netkan.filter(row => !row.frozen).length,
           frozenCount: netkan.filter(row =>  row.frozen).length,
+          metaCount: netkan.filter(row => row.resources.metanetkan).length,
+          nonmetaCount: netkan.filter(row => !row.resources.metanetkan).length,
         });
         this._updateTableSize();
       },
@@ -129,6 +135,12 @@ export default class NetKANs extends React.Component {
   _toggleFrozen() {
     this.setState({showFrozen: !this.state.showFrozen});
   }
+  _toggleMeta() {
+    this.setState({showMeta: !this.state.showMeta});
+  }
+  _toggleNonmeta() {
+    this.setState({showNonmeta: !this.state.showNonmeta});
+  }
   Array_count_if(array, func) {
     return array.reduce((c, elt) => func(elt) ? c + 1 : c, 0);
   }
@@ -144,8 +156,9 @@ export default class NetKANs extends React.Component {
               || (row.last_error && row.last_error.toLowerCase().indexOf(filt) !== -1)
               || (row.last_warnings && row.last_warnings.toLowerCase().indexOf(filt) !== -1);
           })
-        : this.state.data
-    ).filter(row => row.frozen ? this.state.showFrozen : this.state.showActive);
+        : this.state.data)
+        .filter(row => row.frozen ? this.state.showFrozen : this.state.showActive)
+        .filter(row => row.resources.metanetkan ? this.state.showMeta : this.state.showNonmeta);
 
     rows.sort((a, b) => {
       let sortVal = 0;
@@ -245,6 +258,12 @@ export default class NetKANs extends React.Component {
         <label style={labelstyle} htmlFor="toggleActive">{this.state.activeCount} active</label>
         <input type="checkbox" style={checkboxstyle}
           id="toggleActive" checked={this.state.showActive} onChange={this._toggleActive} />
+        <label style={labelstyle} htmlFor="toggleNonmeta">{this.state.nonmetaCount} non-meta</label>
+        <input type="checkbox" style={checkboxstyle}
+          id="toggleNonmeta" checked={this.state.showNonmeta} onChange={this._toggleNonmeta} />
+        <label style={labelstyle} htmlFor="toggleMeta">{this.state.metaCount} meta</label>
+        <input type="checkbox" style={checkboxstyle}
+          id="toggleMeta" checked={this.state.showMeta} onChange={this._toggleMeta} />
         <h1 style={h1style}>NetKANs Indexed</h1>
         <Table
           rowHeight={40}


### PR DESCRIPTION
## Motivation

One of the chief functions of the status page is to summarize issues and allow them to be worked. We might add or remove a vref, add or remove a ModuleManager dependency, submit a fix for a version file, etc.

Metanetkans make it more difficult to resolve many issues. Rather than simply editing a file in a CKAN-owned repo, we have to submit a pull request to the third party repo where the metanetkan lives, which may not be merged or even seen for a long time. It would be nice to be able to assess how we're doing with each group of mods separately, given that the metanetkan group is likely to have more issues for a longer time per mod.

## Changes

Now some new checkboxes at the top allow toggling the inclusion/exclusion of mods with metanetkans and mods without metanetkans:

![image](https://user-images.githubusercontent.com/1559108/115118468-e017bf80-9f68-11eb-828f-9255a8a7f7f8.png)

This way we can toggle off the metanetkan mods to find easily resolved issues more... easily.