### PR TITLE
Sort by last indexed if no errors

### DIFF
--- a/src/javascript/components/NetKANs.jsx
+++ b/src/javascript/components/NetKANs.jsx
@@ -21,12 +21,13 @@ export default class NetKANs extends React.Component {
       filterText: '',
       tableWidth: 200,
       tableHeight: 500,
-      filterBy: 'failed',
       filterId: null,
-      sortBy: 'last_error',
-      sortDir: 'ASC',
+      sortBy: null,
+      sortDir: null,
       activeCount: 0,
       frozenCount: 0,
+      metaCount: 0,
+      nonmetaCount: 0,
       showActive: true,
       showFrozen: false,
       showMeta: true,
@@ -61,6 +62,17 @@ export default class NetKANs extends React.Component {
           metaCount: netkan.filter(row => row.resources.metanetkan).length,
           nonmetaCount: netkan.filter(row => !row.resources.metanetkan).length,
         });
+        if (!this.state.sortBy) {
+            // Sort by errors if any active module has an error,
+            // else sort by last indexed time.
+            this.setState(netkan.some(row => row.last_error && !row.frozen) ? {
+                sortBy: 'last_error',
+                sortDir: 'ASC',
+            } : {
+                sortBy: 'last_indexed',
+                sortDir: 'DESC',
+            });
+        }
         this._updateTableSize();
       },
       error: (xhr, status, err) => {


### PR DESCRIPTION
## Background

The default sort of the status page is currently the error column. If there are errors, this ensures that we will notice them and makes it easy to monitor them.

## Motivation

It's less useful when there are no errors, only warnings. A warning is often a false positive or something out of our control due to metanetkans or version files, which does not need our immediate attention or active monitoring.

Increasingly I find my first action after loading the status page is to sort by last indexed, so I can see what has happened most recently.

## Changes

Now when you load the status page, the default sort is the error column if there are errors, or the last indexed column otherwise. This way the "normal" view would be of recent activity, but if there are any active errors, they would be floated to the top automatically and the red text would catch our eyes.

This only affects the initial load. The page autorefreshes every 5 minutes, and it would not be appropriate to override the sort on every refresh, since the user may have selected it for a purpose.