### PR TITLE
Size table on mount, not after data load

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,4 +10,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build CKAN Status
-        run: npm install && npm run build
+        run: npm install --legacy-peer-deps && npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Build CKAN Status
-        run: npm install && npm run build
+        run: npm install --legacy-peer-deps && npm run build
       - name: Deploy CKAN Status to S3
         run: aws s3 sync ./dist/ s3://status.ksp-ckan.space

--- a/src/javascript/components/NetKANs.jsx
+++ b/src/javascript/components/NetKANs.jsx
@@ -44,6 +44,9 @@ export default class NetKANs extends React.Component {
     setInterval(this.loadNetKANsFromServer, this.props.pollInterval);
     this.loadNetKANsFromServer();
   }
+  componentDidMount() {
+    this._updateTableSize();
+  }
   loadNetKANsFromServer() {
     $.ajax({
       url: this.props.url,
@@ -73,7 +76,6 @@ export default class NetKANs extends React.Component {
                 sortDir: 'DESC',
             });
         }
-        this._updateTableSize();
       },
       error: (xhr, status, err) => {
         console.error(this.props.url, status, err.toString());


### PR DESCRIPTION
## Problem

The [status page](http://status.ksp-ckan.space/) looks like this for a noticeable amount of time after load:

![image](https://user-images.githubusercontent.com/1559108/146848017-eb1a3988-f015-4cb1-b9b3-0cb57751cfa2.png)

## Cause

The dimensions are set by `this._updateTableSize()`, via the `sucess` branch of `loadNetKANsFromServer()`. This means that while the netkans are being loaded, the table has its default size of 200px x 500px.

## Changes

Apparently `componentDidMount()` is the place to do UI updates like this at load. Now we do that, and it seems to provide instant sizing.

I'll probably self-review this so I can see whether it works in production.
