### PR TITLE
Reference netkan.json with relative path, extend README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # NetKAN-status
 Display Status information generated from NetKAN-bot
+
+## Development
+
+To run locally:
+```sh
+npm install --legacy-peer-deps
+npm run build
+mkdir dist/status && wget http://status.ksp-ckan.space/status/netkan.json -O dist/status/netkan.json
+python3 -m http.server --directory dist
+```
+
+The local development server is available at <http://localhost:8000>.
+
+You can also install the [http-server](https://www.npmjs.com/package/http-server) npm package, or any other simple web server that just serves local files.
+
+`netkan.json` is downloaded locally to avoid CORS issues.

--- a/src/javascript/app.jsx
+++ b/src/javascript/app.jsx
@@ -10,7 +10,7 @@ document.body.className = window.localStorage.getItem('darkTheme')
 
 ReactDom.render(
   <NetKANs
-    url="http://status.ksp-ckan.space/status/netkan.json"
+    url="/status/netkan.json"
     pollInterval={300000} />,
   document.body
 );


### PR DESCRIPTION
## Motivation
If we ever change the domain, the netkan.json path inside `app.jsx` will have to be updated manually.
Local development is a bit annoying to set up, because you have to edit the `app.jsx` file to enter a new path for a downloaded copy of `netkan.json`. Original doesn't work because of CORS.

README.md could use some information about how to do local testing. I tend to forget these type of things over time. Also we need `--legacy-peer-deps` with `npm install` now, see #20, this should be mentioned promintently too.

## Changes
The `url` for the `netkan.json` is now `/status/netkan.json`, instead of the full absolute path with scheme etc.
This should work both in production and locally (after the file has been downloaded to `dist/status/`), regardless of domain, port, whatsoever.

README.md has some more information, an easy copy-pasteable shell section with all the commands to get a local server running.
I suggested Python's `http.server`, because I think that one's available by default in all Python 3 installations, so it should be there on most dev's PCs.