### PR TITLE
Highlight filter matches

### DIFF
--- a/src/javascript/app.css
+++ b/src/javascript/app.css
@@ -62,6 +62,9 @@ button {
     display: inline-block;
     min-height: 16px;
 }
+.highlighted {
+    border-radius: 2px;
+}
 
 
 /* Original light theme */
@@ -81,6 +84,11 @@ button {
 }
 .lightTheme .warnings {
     color: hsl(60, 50%, 50%);
+}
+.lightTheme .highlighted {
+    background-color: hsla(60, 100%, 40%, 0.6);
+    box-shadow:       0 0 1px 2px
+                      hsla(60, 100%, 40%, 0.6);
 }
 
 /* Dark theme */
@@ -144,4 +152,10 @@ button {
     background-color: rgb(0, 0, 0);
     color:            rgba(255, 255, 255, 0.88);
     border-color:     rgba(255, 255, 255, 0.2);
+}
+.darkTheme .highlighted {
+    color:            rgb(0, 0, 0);
+    background-color: hsla(65, 100%, 50%, 0.6);
+    box-shadow:       0 0 1px 2px
+                      hsla(65, 100%, 50%, 0.6);
 }

--- a/src/javascript/components/Highlighted.js
+++ b/src/javascript/components/Highlighted.js
@@ -1,0 +1,78 @@
+import React, { PureComponent } from 'react';
+
+/**
+ * https://nabilhassein.github.io/blog/unfold/
+ * https://raganwald.com/2016/11/30/anamorphisms-in-javascript.html
+ * func: (...params) => [[elements], done, ...nextParams]
+ *
+ * @generator
+ * @param {function} func
+ * @param  {...any} params
+ * @yields {...any} Whatever func returns in its first element
+ */
+export function *unfold(func, ...params) {
+    const [elements, done, ...nextParams] = func(...params);
+    yield* elements;
+    if (!done)
+        yield* unfold(func, ...nextParams);
+}
+
+const diacriticRegex = /[\u0300-\u036f]/g;
+
+/**
+ * @param {string} s
+ * @returns {string} input normalized for searchability
+ */
+export function casefold(s) {
+    return s.normalize('NFD')
+            .replace(diacriticRegex, '')
+            .toLowerCase();
+}
+
+/**
+ * @generator
+ * @param {string} content
+ * @param {string} toHighlight
+ * @param {string=} hlClass
+ * @param {number=} start
+ * @yields {string|JSX.Element} Spans with hlClass for CSS class for highlighted text, in between strings for unhighlighted text
+ */
+export function *highlightedElements(content, toHighlight, hlClass, start) {
+    if (toHighlight.length < 1)
+        yield content;
+    else
+        yield* unfold(
+            /**
+             * @param {string} whole
+             * @param {string} searchFor
+             * @param {number} start
+             * @returns {[(string|JSX.Element)[], true] | [(string|JSX.Element)[], false, string, string, number]}
+             */
+            (whole, searchFor, start) => {
+                const where = whole.indexOf(searchFor, start);
+                return where === -1
+                    // No matches left: remainder as plain
+                    ? ([[content.substring(start)],
+                        true])
+                    // Found one: prefix as plain, then match as highlighted
+                    : [[content.substring(start, where),
+                        (<span key={where}
+                               className={hlClass}>
+                            {content.substring(where,
+                                               where + searchFor.length)}</span>)],
+                       false,
+                       whole, searchFor, where + searchFor.length];
+            },
+            casefold(content),
+            casefold(toHighlight),
+            start || 0);
+}
+
+export default class Highlighted extends PureComponent {
+    render() {
+        const { Content, Search, HighlightClassName } = this.props;
+        return <span>
+            {[...highlightedElements(Content || '', Search || '', HighlightClassName)]}
+        </span>;
+    }
+}

--- a/src/javascript/lib/debounce.js
+++ b/src/javascript/lib/debounce.js
@@ -1,0 +1,21 @@
+/**
+ * https://www.freecodecamp.org/news/javascript-debounce-example/
+ * Improvements:
+ * - Execute immediately if a condition is met
+ * - Pass the events to the functions
+ *
+ * @param {function(...any): boolean} skipFunc
+ * @param {function(...any): void} doneFunc
+ * @param {number} timeout
+ * @returns {function(...any): void}
+ */
+export default function debounce(skipFunc, doneFunc, timeout = 250) {
+    let timer;
+    return (...args) => {
+        clearTimeout(timer);
+        if (skipFunc(...args))
+            doneFunc(...args);
+        else
+            timer = setTimeout(doneFunc, timeout, ...args);
+    };
+}


### PR DESCRIPTION
## Motivation

The search box on the status page is very useful, but since we search both the identifier and the warnings/errors, telling what exactly it matched on a given row can require some effort.

## Changes

- Now a new `Highlighted` component returns a `<span/>` (`<Fragment/>` would be better, but it was created in React v16, and we're on v15) containing a list of plain text strings for unmatched pieces and `<span className="highlighted"/>` containing matched pieces
- Now `app.css` defines a `.highlighted` class with background color and border styles for highlights
- Now the table rows use a `Highlighted` element for the identifier and warnings/errors
- Since we now modify the DOM of rows during filter updates, very short searches (with very many matched rows) are slower, so the input handler is debounced so it doesn't process searches of 1–3 characters unless you stop typing for 250 milliseconds

After these changes, the part of the row that matched the search term is highlighted. Dark theme:

![image](https://user-images.githubusercontent.com/1559108/186712834-4eda6193-e517-4e7c-96b6-7e3eb15b6b55.png)

Light theme:

![image](https://user-images.githubusercontent.com/1559108/186712782-5ca5c2e6-0afa-4f62-b98e-211db14fc4f8.png)

