### PR TITLE
Multi-game

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To run locally:
 ```sh
 npm install
 npm run build
-mkdir dist/status && wget http://status.ksp-ckan.space/status/netkan.json -O dist/status/netkan.json
+mkdir dist/status && wget http://status.ksp-ckan.space/status/netkan.json -O dist/status/netkan.json && wget http://status.ksp-ckan.space/status/netkan-ksp2.json -O dist/status/netkan-ksp2.json
 python3 -m http.server --directory dist
 ```
 

--- a/src/javascript/app.jsx
+++ b/src/javascript/app.jsx
@@ -8,9 +8,34 @@ import customStyles from './app.css';
 document.body.className = window.localStorage.getItem('darkTheme')
     ? 'darkTheme' : 'lightTheme';
 
+const ksp = {
+  'id': 'ksp',
+  'name': 'KSP',
+  'status': '/status/netkan.json',
+  'netkan': (ident, frozen) =>
+    frozen ? `https://github.com/KSP-CKAN/NetKAN/tree/master/NetKAN/${ident}.frozen`
+           : `https://github.com/KSP-CKAN/NetKAN/tree/master/NetKAN/${ident}.netkan`,
+  'history': (ident, frozen) =>
+    frozen ? `https://github.com/KSP-CKAN/NetKAN/commits/master/NetKAN/${ident}.frozen`
+           : `https://github.com/KSP-CKAN/NetKAN/commits/master/NetKAN/${ident}.netkan`,
+  'metadata': (ident) => `https://github.com/KSP-CKAN/CKAN-meta/tree/master/${ident}`,
+};
+
+const ksp2 = {
+  'id': 'ksp2',
+  'name': 'KSP2',
+  'status': '/status/netkan-ksp2.json',
+  'netkan': (ident, frozen) =>
+    frozen ? `https://github.com/KSP-CKAN/KSP2-NetKAN/tree/main/NetKAN/${ident}.frozen`
+           : `https://github.com/KSP-CKAN/KSP2-NetKAN/tree/main/NetKAN/${ident}.netkan`,
+  'history': (ident, frozen) =>
+    frozen ? `https://github.com/KSP-CKAN/KSP2-NetKAN/commits/main/NetKAN/${ident}.frozen`
+           : `https://github.com/KSP-CKAN/KSP2-NetKAN/commits/main/NetKAN/${ident}.netkan`,
+  'metadata': (ident) => `https://github.com/KSP-CKAN/KSP2-CKAN-meta/tree/main/${ident}`,
+};
+
 ReactDom.render(
-  <NetKANs
-    url="/status/netkan.json"
-    pollInterval={300000} />,
+  <NetKANs games={[ksp, ksp2]}
+           pollInterval={300000} />,
   document.body
 );


### PR DESCRIPTION
## Motivation

Initially, the KSP2 mods were mixed into the status page with wrong links and clobbering of some KSP1 identifiers. Currently they are hidden.

## Changes

- Objects called `ksp` and `ksp2` in `app.jsx` define all the info we need about each game and are passed in a list to the `games` property of the `NetKANs` component
- The status JSON file for each game is fetched, and the rows are generated once they're all received or failed
- The per-mod links are now correct for all mods
- Each game gets a count-enabled checkbox filter just like meta/frozen/etc. Since we now have too many checkboxes to fit in the previous layout, they start a new line in the layout and everything is packed a bit tighter:
  ![image](https://user-images.githubusercontent.com/1559108/232585468-0325727d-41f4-4ad1-9f4f-1b640f42c84b.png)
