### PR TITLE
Calculate table size correctly

### DIFF
--- a/src/javascript/components/NetKANs.jsx
+++ b/src/javascript/components/NetKANs.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import {Table, Column, Cell} from 'fixed-data-table';
 import $ from 'jquery';
 
@@ -122,10 +123,17 @@ export default class NetKANs extends React.Component {
     this._updateTimer = setTimeout(this._updateTableSize, 16);
   }
   _updateTableSize() {
-    const widthOffset = window.innerWidth < 680 ? 0 : 10;
+    const myElt = ReactDOM.findDOMNode(this);
+    const { paddingLeft, paddingTop, paddingBottom, paddingRight } = getComputedStyle(myElt);
+    const bottom = window.scrollY + Math.max(...
+                     ['input', 'h1'].map((tagName) => myElt.getElementsByTagName(tagName))
+                                    // of course getElementsByTagName can't simply return a sensible array
+                                    .flatMap((htmlColl) => Array.prototype.slice.call(htmlColl))
+                                    .map((elt) => elt.getBoundingClientRect().bottom
+                                                  + parseFloat(getComputedStyle(elt).marginBottom)));
     this.setState({
-      tableWidth: window.innerWidth - widthOffset,
-      tableHeight: window.innerHeight - 45,
+      tableWidth:  window.innerWidth  - parseFloat(paddingLeft) - parseFloat(paddingRight),
+      tableHeight: window.innerHeight - parseFloat(paddingTop)  - parseFloat(paddingBottom) - bottom,
     });
   }
   _onFilterChange() {


### PR DESCRIPTION
## Problem

No matter what size the browser window is, http://status.ksp-ckan.space/ always has scrollbars.

## Cause

The `fixed-data-table` component requires specifying its width and height, which makes it difficult to use correctly when every other part of the layout is handled by CSS. Currently it's done with a couple of magic numbers that became out of date the last time the header was changed.

## Changes

Now we accurately calculate the available size by finding the actual bottom coordinates of the elements in the header and checking the container's padding, so the table always fits correctly in the available space.
